### PR TITLE
"prop-drilling" ActivityAndProps is no more!

### DIFF
--- a/app/src/main/java/com/shiftstudio/workflowshenanigans/ShenanigansModule.kt
+++ b/app/src/main/java/com/shiftstudio/workflowshenanigans/ShenanigansModule.kt
@@ -3,10 +3,10 @@ package com.shiftstudio.workflowshenanigans
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.components.ActivityComponent
 
 @Module
-@InstallIn(SingletonComponent::class)
+@InstallIn(ActivityComponent::class)
 abstract class ShenanigansModule {
 
     @Binds

--- a/app/src/main/java/com/shiftstudio/workflowshenanigans/ShenanigansWorkflow.kt
+++ b/app/src/main/java/com/shiftstudio/workflowshenanigans/ShenanigansWorkflow.kt
@@ -3,8 +3,6 @@
 package com.shiftstudio.workflowshenanigans
 
 import android.os.Parcelable
-import androidx.activity.ComponentActivity
-import com.shiftstudio.workflowshenanigans.ShenanigansWorkflow.ActivityAndProps
 import com.shiftstudio.workflowshenanigans.account.AccountViewRegistry
 import com.shiftstudio.workflowshenanigans.account.AccountWorkflow
 import com.shiftstudio.workflowshenanigans.login.LoginViewRegistry
@@ -25,13 +23,7 @@ import com.squareup.workflow1.ui.toSnapshot
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
-interface ShenanigansWorkflow : Workflow<ActivityAndProps<Unit>, Nothing, BackStackScreen<Any>> {
-
-    data class ActivityAndProps<R>(
-        val activity: ComponentActivity,
-        val props: R
-    )
-}
+interface ShenanigansWorkflow : Workflow<Unit, Nothing, BackStackScreen<Any>>
 
 val ShenanigansViewRegistry: ViewRegistry = ViewRegistry(BackStackContainer, NamedViewFactory) +
     AccountViewRegistry +
@@ -41,7 +33,7 @@ class ShenanigansWorkflowImpl @Inject constructor(
     private val welcomeWorkflow: WelcomeWorkflow,
     private val accountWorkflow: AccountWorkflow,
 ) : ShenanigansWorkflow,
-    StatefulWorkflow<ActivityAndProps<Unit>, ShenanigansWorkflowImpl.State, Nothing, BackStackScreen<Any>>() {
+    StatefulWorkflow<Unit, ShenanigansWorkflowImpl.State, Nothing, BackStackScreen<Any>>() {
 
     sealed class State : Parcelable {
         @Parcelize
@@ -51,11 +43,11 @@ class ShenanigansWorkflowImpl @Inject constructor(
         object Account : State()
     }
 
-    override fun initialState(props: ActivityAndProps<Unit>, snapshot: Snapshot?): State =
+    override fun initialState(props: Unit, snapshot: Snapshot?): State =
         snapshot?.toParcelable() ?: State.Welcome
 
     override fun render(
-        renderProps: ActivityAndProps<Unit>,
+        renderProps: Unit,
         renderState: State,
         context: RenderContext
     ): BackStackScreen<Any> {

--- a/app/src/main/java/com/shiftstudio/workflowshenanigans/account/AccountModule.kt
+++ b/app/src/main/java/com/shiftstudio/workflowshenanigans/account/AccountModule.kt
@@ -3,10 +3,10 @@ package com.shiftstudio.workflowshenanigans.account
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.components.ActivityComponent
 
 @Module
-@InstallIn(SingletonComponent::class)
+@InstallIn(ActivityComponent::class)
 abstract class AccountModule {
 
     @Binds

--- a/app/src/main/java/com/shiftstudio/workflowshenanigans/account/AccountWorkflow.kt
+++ b/app/src/main/java/com/shiftstudio/workflowshenanigans/account/AccountWorkflow.kt
@@ -2,7 +2,6 @@ package com.shiftstudio.workflowshenanigans.account
 
 import android.os.Parcelable
 import android.util.Log
-import com.shiftstudio.workflowshenanigans.ShenanigansWorkflow.ActivityAndProps
 import com.shiftstudio.workflowshenanigans.account.AccountWorkflow.Back
 import com.shiftstudio.workflowshenanigans.account.AccountWorkflowImpl.State
 import com.shiftstudio.workflowshenanigans.login.LoginWorkflow
@@ -20,7 +19,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
-interface AccountWorkflow : Workflow<ActivityAndProps<Unit>, Back, Any> {
+interface AccountWorkflow : Workflow<Unit, Back, Any> {
 
     object Back
 }
@@ -32,7 +31,7 @@ data class UserRendering(val user: User, val onSignOut: () -> Unit)
 class AccountWorkflowImpl @Inject constructor(
     private val userRepository: UserRepository,
     private val loginWorkflow: LoginWorkflow,
-) : AccountWorkflow, StatefulWorkflow<ActivityAndProps<Unit>, State, Back, Any>() {
+) : AccountWorkflow, StatefulWorkflow<Unit, State, Back, Any>() {
 
     sealed class State : Parcelable {
         @Parcelize
@@ -45,11 +44,11 @@ class AccountWorkflowImpl @Inject constructor(
         data class Authorized(val user: User, val signingOut: Boolean = false) : State()
     }
 
-    override fun initialState(props: ActivityAndProps<Unit>, snapshot: Snapshot?): State =
+    override fun initialState(props: Unit, snapshot: Snapshot?): State =
         snapshot?.toParcelable() ?: State.Loading
 
     override fun render(
-        renderProps: ActivityAndProps<Unit>,
+        renderProps: Unit,
         renderState: State,
         context: RenderContext
     ): Any {

--- a/app/src/main/java/com/shiftstudio/workflowshenanigans/infrastructure/ContextExt.kt
+++ b/app/src/main/java/com/shiftstudio/workflowshenanigans/infrastructure/ContextExt.kt
@@ -1,0 +1,22 @@
+package com.shiftstudio.workflowshenanigans.infrastructure
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+
+fun Context.findActivity(): ComponentActivity {
+    val context = this
+
+    return context.let {
+        var ctx = it
+        while (ctx is ContextWrapper) {
+            if (ctx is ComponentActivity) {
+                return@let ctx
+            }
+            ctx = ctx.baseContext
+        }
+        throw IllegalStateException(
+            "Expected an activity context for creating a HiltViewModelFactory but instead found: $ctx"
+        )
+    }
+}

--- a/app/src/main/java/com/shiftstudio/workflowshenanigans/infrastructure/MainActivity.kt
+++ b/app/src/main/java/com/shiftstudio/workflowshenanigans/infrastructure/MainActivity.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.shiftstudio.workflowshenanigans.ShenanigansViewRegistry
 import com.shiftstudio.workflowshenanigans.ShenanigansWorkflow
-import com.shiftstudio.workflowshenanigans.ShenanigansWorkflow.ActivityAndProps
 import com.shiftstudio.workflowshenanigans.infrastructure.theme.WorkflowShenanigansTheme
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
@@ -37,9 +36,7 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colors.background
                 ) {
 
-                    val rendering by shenanigansWorkflow.renderAsState(
-                        props = ActivityAndProps(this, Unit), onOutput = {}
-                    )
+                    val rendering by shenanigansWorkflow.renderAsState(Unit, onOutput = {})
 
                     WorkflowRendering(
                         rendering,

--- a/app/src/main/java/com/shiftstudio/workflowshenanigans/login/LoginModule.kt
+++ b/app/src/main/java/com/shiftstudio/workflowshenanigans/login/LoginModule.kt
@@ -3,10 +3,10 @@ package com.shiftstudio.workflowshenanigans.login
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.components.ActivityComponent
 
 @Module
-@InstallIn(SingletonComponent::class)
+@InstallIn(ActivityComponent::class)
 abstract class LoginModule {
 
     @Binds


### PR DESCRIPTION
With Hilt, it's really easily to inject an @ActivityContext into a Workflow, aka into LoginWorkflow to get a hold of ComponentActivity.activityResultRegistry. hurra! 🎉